### PR TITLE
Adding checks on m4

### DIFF
--- a/.github/workflows/llvm.yml
+++ b/.github/workflows/llvm.yml
@@ -36,6 +36,8 @@ jobs:
       # Runs a set of commands using the runners shell
       - name: Run the CPU feature extractor
         run: ./a.out
+      - name: Checking the version of make, automake, autoconf and m4
+        run: make --version && m4 --version && autoconf --version && automake --version
       - name: Clonning LLVM master branch && gollvm related repos.
         run:  cd $GITHUB_WORKSPACE/clang_test_cpu_features && git clone https://github.com/llvm/llvm-project.git && cd llvm-project/llvm/tools && git clone https://go.googlesource.com/gollvm &&  cd gollvm && git clone https://go.googlesource.com/gofrontend && cd libgo && git clone https://github.com/libffi/libffi.git && git clone https://github.com/ianlancetaylor/libbacktrace.git
       - name: Compiling & linking gollvm


### PR DESCRIPTION
Checking whether m4, automake, autoconf are present - those are required to build sub-dependencies